### PR TITLE
Accept both backslashes and slashes as path separators in web exports

### DIFF
--- a/src/anki_simulator/__init__.py
+++ b/src/anki_simulator/__init__.py
@@ -56,11 +56,7 @@ def on_deck_browser_will_show_options_menu(menu, deck_id):
 
 # Web exports
 
-import os
-import re
-
-s = re.escape(os.path.sep)
-aqt.mw.addonManager.setWebExports(__name__, f"gui{s}web{s}.*")
+aqt.mw.addonManager.setWebExports(__name__, r"gui(/|\\)web(/|\\).*")
 
 # Main menu
 


### PR DESCRIPTION
Starting with Anki 2.1.28 backslashes are now no longer supported,
resulting in the graph view no longer loading on Windows machines.

This change replaces the previous os-specific path separators with
a simple RegEx to match both regular slashes and backslashes.

By supporting both, the add-on should continue to work both on older
versions of Anki that do require backslashes as path separators on
Windows, and on 2.1.28+ where path separators have been unified to
regular slashes.