### PR TITLE
Plot cumulative change in number of mature cards

### DIFF
--- a/src/anki_simulator/gui/dialogs.py
+++ b/src/anki_simulator/gui/dialogs.py
@@ -602,10 +602,18 @@ class SimulatorDialog(QDialog):
                 self.dialog.simulationTitleTextfield.text()
             )
 
+        downSampled = downsampleList(data, self.config["max_number_of_data_points"])
+
         self.dialog.simulationGraph.addDataSet(
             simulationTitle,
-            downsampleList(data, self.config["max_number_of_data_points"]),
+            [{"x": r["x"], "y": r["reviews"]} for r in downSampled]
         )
+
+        self.dialog.simulationGraph.addDataSet(
+            simulationTitle + " matures",
+            [{"x": r["x"], "y": r["matures"]} for r in downSampled]
+        )
+
         self.dialog.simulationTitleTextfield.setText(
             "Simulation {}".format(self.numberOfSimulations + 1)
         )

--- a/src/anki_simulator/gui/graph.py
+++ b/src/anki_simulator/gui/graph.py
@@ -72,6 +72,7 @@ class GraphWebView(AnkiWebView):
 
     def clearLastDataset(self):
         self._runJavascript("clearLastDataset()")
+        self._runJavascript("clearLastDataset()")
 
     def _runJavascript(self, script: str):
         # workaround for widget focus stealing issues

--- a/src/anki_simulator/review_simulator.py
+++ b/src/anki_simulator/review_simulator.py
@@ -368,10 +368,10 @@ class ReviewSimulator:
                             card.state = CARD_STATE_MATURE
                         daysToAdd = card.ivl
 
-                    if original_state != CARD_STATE_MATURE and card.state == CARD_STATE_MATURE:
-                        matureDeltas[dayIndex] += 1
-                    elif original_state == CARD_STATE_MATURE and card.state != CARD_STATE_MATURE:
-                        matureDeltas[dayIndex] -= 1
+                if original_state != CARD_STATE_MATURE and card.state == CARD_STATE_MATURE:
+                    matureDeltas[dayIndex] += 1
+                elif original_state == CARD_STATE_MATURE and card.state != CARD_STATE_MATURE:
+                    matureDeltas[dayIndex] -= 1
 
                 if (
                     daysToAdd is not None

--- a/src/anki_simulator/review_simulator.py
+++ b/src/anki_simulator/review_simulator.py
@@ -368,6 +368,7 @@ class ReviewSimulator:
                             card.state = CARD_STATE_MATURE
                         daysToAdd = card.ivl
 
+                print(f"{original_state} -> {card.state}")
                 if original_state != CARD_STATE_MATURE and card.state == CARD_STATE_MATURE:
                     matureDeltas[dayIndex] += 1
                 elif original_state == CARD_STATE_MATURE and card.state != CARD_STATE_MATURE:


### PR DESCRIPTION
Draft PR that answered a question I had about approximately when I'd be done with a new deck of cards. Similar to https://github.com/giovannihenriksen/Anki-Simulator/issues/40. The PR is definitely still in the "proof of concept" phase and details like the graph titles shouldn't be taken too seriously yet.

This PR adds an additional simulation to the graphs which shows the cumulative change to the number of mature cards in the simulation. E.g. if on day x a card goes from young -> mature, that counts as a +1 against the previous value. If a card goes from mature -> relearn, that counts as a -1.

If this sounds like something you'd like for Anki-Simulator, I could use some guidance before I pretend it's ready for a thorough review. Some questions I'm still thinking about are whether there are any changes to the options needed (e.g. show / hide mature count), changes to the graph presentation (should the review and mature graphs be separately toggleable?), and whether it would make more sense to add in the baseline number of mature cards (could throw the scale of the graph off, but would be a clearer presentation to me).

![Screenshot from 2021-01-04 00-51-50](https://user-images.githubusercontent.com/4087850/103505000-0d5fb800-4e27-11eb-9bdb-04abd6226722.png)

To test this, clone my fork and run `aab build plot-mature-count` and install the .addon artifact from the Anki plugin menu.
