### PR TITLE
Fix learning steps > 9 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.2] - 2021-04-30
+
+### Fixed
+- GiovanniHenriksen: Fixed a bug that would cause a crash or incorrect simulations for users with a number of learning or lapse steps greater than 9 (Thanks to baderj for reporting)
 ## [1.1.1] - 2021-02-21
 
 ### Added

--- a/src/anki_simulator/collection_simulator.py
+++ b/src/anki_simulator/collection_simulator.py
@@ -136,7 +136,7 @@ class CollectionSimulator:
                     id=card.id,
                     ease=starting_ease,
                     state=CARD_STATE_LEARNING,
-                    step=max(number_of_learning_steps - (card.left % 10), -1),
+                    step=max(number_of_learning_steps - (card.left % 1000), -1),
                 )
                 if cardDue < days_to_simulate:
                     dateArray[cardDue].append(review)
@@ -189,7 +189,7 @@ class CollectionSimulator:
                         ease=card.factor / 10,
                         state=CARD_STATE_RELEARN,
                         ivl=card.ivl,
-                        step=max(number_of_lapse_steps - (card.left % 10), -1),
+                        step=max(number_of_lapse_steps - (card.left % 1000), -1),
                     )
                     dateArray[cardDue].append(review)
 


### PR DESCRIPTION
Fixed a bug that would cause a crash or incorrect simulations for users with a number of learning or lapse steps greater than 9 (Thanks to baderj for reporting)