### PR TITLE
Fix setting DeckChooser deck in 2.1.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Next version] - Unknown date
+
+### Fixed
+- RumovZ: Fixed crash for Anki version 2.1.45 and higher. Thanks to AnKingMed for reporting.
 
 ## [1.1.1] - 2021-02-21
 

--- a/src/anki_simulator/gui/dialogs.py
+++ b/src/anki_simulator/gui/dialogs.py
@@ -95,9 +95,7 @@ class SimulatorDialog(QDialog):
         self.setupGraph()
         self.deckChooser = aqt.deckchooser.DeckChooser(self.mw, self.dialog.deckChooser)
         if deck_id is not None:
-            deck_name = self.mw.col.decks.nameOrNone(deck_id)
-            if deck_name:
-                self.deckChooser.setDeckName(deck_name)
+            self.deckChooser.selected_deck_id = deck_id
         self.dialog.simulateButton.clicked.connect(self.simulate)
         self.dialog.loadDeckConfigurationsButton.clicked.connect(
             self.loadDeckConfigurations

--- a/src/anki_simulator/gui/dialogs.py
+++ b/src/anki_simulator/gui/dialogs.py
@@ -95,7 +95,12 @@ class SimulatorDialog(QDialog):
         self.setupGraph()
         self.deckChooser = aqt.deckchooser.DeckChooser(self.mw, self.dialog.deckChooser)
         if deck_id is not None:
-            self.deckChooser.selected_deck_id = deck_id
+            if hasattr(self.deckChooser, 'selected_deck_id'): # Anki >= 2.1.45
+                self.deckChooser.selected_deck_id = deck_id
+            else:
+                deck_name = self.mw.col.decks.nameOrNone(deck_id)
+                if deck_name:
+                    self.deckChooser.setDeckName(deck_name)
         self.dialog.simulateButton.clicked.connect(self.simulate)
         self.dialog.loadDeckConfigurationsButton.clicked.connect(
             self.loadDeckConfigurations


### PR DESCRIPTION
This will require a separate branch for Anki 2.1.45+ on AnkiWeb, of course. Closes #58.